### PR TITLE
Allow configuration of currency symbol instead of using language-base…

### DIFF
--- a/config/template_config.ini
+++ b/config/template_config.ini
@@ -41,6 +41,9 @@ currency = EUR
 ; Currency exp parameter. You can find that on https://core.telegram.org/bots/payments/currencies.json.
 ; It has a value of 2 in most currencies (EUR, USD, GBP...)
 currency_exp = 2
+; Currency symbol which is show to the client users when displaying prices and transaction values
+; If not defined here, default language specific currency symbol from strings would be used
+currency_symbol = "€"
 
 # Credit card payment settings
 [Credit Card]

--- a/config/template_config.ini
+++ b/config/template_config.ini
@@ -5,7 +5,7 @@
 # Config file parameters
 [Config]
 ; Config file version. DO NOT EDIT THIS!
-version = 14
+version = 15
 ; Set this to no when you are done editing the file
 is_template = yes
 ; Language code for string file

--- a/utils.py
+++ b/utils.py
@@ -47,7 +47,7 @@ class Price:
         return f"<Price of value {self.value}>"
 
     def __str__(self):
-        return strings.currency_format_string.format(symbol=strings.currency_symbol,
+        return strings.currency_format_string.format(symbol=(config["Payments"]["currency_symbol"] or strings.currency_symbol),
                                                      value="{0:.2f}".format(
                                                          self.value / (10 ** int(config["Payments"]["currency_exp"]))))
 


### PR DESCRIPTION
Considering that system used currency is configurable option, the currency symbol also should be configurable, and not language specific
Also valid for countries with multiple language selection demand but single currency