### PR TITLE
fix order-transaction one-to-one relation

### DIFF
--- a/database.py
+++ b/database.py
@@ -181,6 +181,7 @@ class Transaction(DeferredReflection, TableDeclarativeBase):
 
     # Order ID
     order_id = Column(Integer, ForeignKey("orders.order_id"))
+    order = relationship("Order", back_populates="transaction")
 
     # Extra table parameters
     __tablename__ = "transactions"
@@ -244,7 +245,7 @@ class Order(DeferredReflection, TableDeclarativeBase):
     # Extra details specified by the purchasing user
     notes = Column(Text)
     # Linked transaction
-    transaction = relationship("Transaction", backref="order", uselist=False)
+    transaction = relationship("Transaction", back_populates="order", uselist=False)
 
     # Extra table parameters
     __tablename__ = "orders"

--- a/database.py
+++ b/database.py
@@ -181,7 +181,6 @@ class Transaction(DeferredReflection, TableDeclarativeBase):
 
     # Order ID
     order_id = Column(Integer, ForeignKey("orders.order_id"))
-    order = relationship("Order")
 
     # Extra table parameters
     __tablename__ = "transactions"
@@ -245,7 +244,7 @@ class Order(DeferredReflection, TableDeclarativeBase):
     # Extra details specified by the purchasing user
     notes = Column(Text)
     # Linked transaction
-    transaction = relationship("Transaction", uselist=False)
+    transaction = relationship("Transaction", backref="order", uselist=False)
 
     # Extra table parameters
     __tablename__ = "orders"


### PR DESCRIPTION
fix sqlalchemy:latest warning:
> SAWarning: relationship 'Order.transaction' will copy column orders.order_id to column transactions.order_id, which conflicts with relationship(s): 'Transaction.order' (copies orders.order_id to transactions.order_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only.