### PR TITLE
fix sqlalchemy exception

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -173,8 +173,6 @@ class Worker(threading.Thread):
             self.user = db.User(w=self)
             # Add the new record to the db
             self.session.add(self.user)
-            # Flush the session to get an userid
-            self.session.flush()
             # If the will be owner flag is set
             if will_be_owner:
                 # Become owner
@@ -649,7 +647,6 @@ class Worker(threading.Thread):
                          notes=notes if not isinstance(notes, CancelSignal) else "")
         # Add the record to the session and get an ID
         self.session.add(order)
-        self.session.flush()
         # For each product added to the cart, create a new OrderItem
         for product in cart:
             # Create {quantity} new OrderItems


### PR DESCRIPTION
1. No need to flush when `session.autoflush==True`
2. When the second session (another user) comes into operation sqlalchemy throws an exception. In other words the bot was able to serve one user only.

To reproduce:
1. Telegram1 -> start order. Pause during payment processing.
2. Telegram2 -> /start (when new user) or start new order