### PR TITLE
fix-2 sqlalchemy exception

### DIFF
--- a/database.py
+++ b/database.py
@@ -297,6 +297,7 @@ class OrderItem(DeferredReflection, TableDeclarativeBase):
     product = relationship("Product")
     # The order in which this item is being purchased
     order_id = Column(Integer, ForeignKey("orders.order_id"), nullable=False)
+    order = relationship("Order")
 
     # Extra table parameters
     __tablename__ = "orderitems"

--- a/worker.py
+++ b/worker.py
@@ -652,7 +652,7 @@ class Worker(threading.Thread):
             # Create {quantity} new OrderItems
             for i in range(0, cart[product][1]):
                 order_item = db.OrderItem(product=cart[product][0],
-                                          order_id=order.order_id)
+                                          order=order)
                 self.session.add(order_item)
         # Ensure the user has enough credit to make the purchase
         credit_required = self.__get_cart_value(cart) - self.user.credit


### PR DESCRIPTION
I'm not sure a proper way fix but the payment works.

Exception was:
`(raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(sqlite3.IntegrityError) NOT NULL constraint failed: orderitems.order_id [SQL: INSERT INTO orderitems (product_id, order_id) VALUES (?, ?)] [parameters: (3, None)]
(Background on this error at: http://sqlalche.me/e/14/gkpj)`
After the successful payment.
Sorry again for the last commit 730fa96e56a09d681624a93a56f428d92b0afc27