### PR TITLE
Support tips (even if not recommended)

### DIFF
--- a/config/template_config.toml
+++ b/config/template_config.toml
@@ -68,6 +68,14 @@ max_amount = 10000
 # The preset selections that can be made when adding credit to the wallet with a credit card
 # Presets are pipe-separated |, and should never be outside the bounds provided by the min_amount and max_amount options
 payment_presets = [10.00, 25.00, 50.00, 100.00]
+# Suggested tip amounts in minimum currency units
+# Maximum 4 values; if the array is empty, the feature is disabled
+# Enabling this feature is not recommended, as it may be confusing for the users
+# tip_presets = [100, 250, 500, 1000]  # €1.00 €2.50 €5.00 €10.00
+tip_presets = []
+# Maximum tip amount in minimum currency units
+# max_tip_amount = 1000
+max_tip_amount = 0
 # Make the user pay a extra fee when adding credit to the wallet with a credit card
 # The formula for determining the total cost is:
 # cost = added_funds + added_funds * fee_percentage / 100 + fee_fixed

--- a/worker.py
+++ b/worker.py
@@ -846,7 +846,10 @@ class Worker(threading.Thread):
                               need_name=self.cfg["Payments"]["CreditCard"]["name_required"],
                               need_email=self.cfg["Payments"]["CreditCard"]["email_required"],
                               need_phone_number=self.cfg["Payments"]["CreditCard"]["phone_required"],
-                              reply_markup=inline_keyboard)
+                              reply_markup=inline_keyboard,
+                              max_tip_amount=self.cfg["Payments"]["CreditCard"]["max_tip_amount"],
+                              suggested_tip_amounts=self.cfg["Payments"]["CreditCard"]["tip_presets"],
+                              )
         # Wait for the precheckout query
         precheckoutquery = self.__wait_for_precheckoutquery(cancellable=True)
         # Check if the user has cancelled the invoice
@@ -859,7 +862,7 @@ class Worker(threading.Thread):
         successfulpayment = self.__wait_for_successfulpayment(cancellable=False)
         # Create a new database transaction
         transaction = db.Transaction(user=self.user,
-                                     value=int(successfulpayment.total_amount) - fee,
+                                     value=int(amount),
                                      provider="Credit Card",
                                      telegram_charge_id=successfulpayment.telegram_payment_charge_id,
                                      provider_charge_id=successfulpayment.provider_payment_charge_id)


### PR DESCRIPTION
I added tips support to the `Add credit → Credit card` menu.

It seems fine, but please test it out on your bots as I think it might break something.

If no problems arise, I'll merge this in a few days.