### PR TITLE
Extend order info to all transactions

### DIFF
--- a/database.py
+++ b/database.py
@@ -272,24 +272,27 @@ class Order(TableDeclarativeBase):
         else:
             status_emoji = w.loc.get("emoji_not_processed")
             status_text = w.loc.get("text_not_processed")
-        if user and w.cfg["Appearance"]["full_order_info"] == "no":
+        if user or w.cfg["Appearance"]["full_order_info"] == "no":
             return w.loc.get("user_order_format_string",
                              status_emoji=status_emoji,
                              status_text=status_text,
                              items=items,
-                             notes=self.notes,
-                             value=str(w.Price(-self.transaction.value))) + \
-                   (w.loc.get("refund_reason", reason=self.refund_reason) if self.refund_date is not None else "")
+                             value=str(w.Price(-self.transaction.value))) + "\n" + \
+                   (w.loc.get("order_notes_string", notes=self.notes) if self.notes else "") + \
+                   (w.loc.get("refund_reason", reason=self.refund_reason) if self.refund_date else "")
         else:
             return status_emoji + " " + \
-                   w.loc.get("order_number", id=self.order_id) + "\n" + \
+                   w.loc.get("order_number", id=self.order_id) + "\n\n" + \
+                   (w.loc.get("order_info_name", name=self.transaction.payment_name) if self.transaction.payment_name else "") + \
+                   (w.loc.get("order_info_phone", phone=self.transaction.payment_phone) if self.transaction.payment_phone else "") + \
+                   (w.loc.get("order_info_email", email=self.transaction.payment_email) if self.transaction.payment_email else "") + \
                    w.loc.get("order_format_string",
                              user=self.user.mention(),
                              date=self.creation_date.isoformat(),
                              items=items,
-                             notes=self.notes if self.notes is not None else "",
-                             value=str(w.Price(-self.transaction.value))) + \
-                   (w.loc.get("refund_reason", reason=self.refund_reason) if self.refund_date is not None else "")
+                             value=str(w.Price(-self.transaction.value))) + "\n" + \
+                   (w.loc.get("order_notes_string", notes=self.notes) if self.notes else "") + \
+                   (w.loc.get("refund_reason", reason=self.refund_reason) if self.refund_date else "")
 
 
 class OrderItem(TableDeclarativeBase):

--- a/strings/en.py
+++ b/strings/en.py
@@ -29,16 +29,18 @@ order_format_string = "by {user}\n" \
                       "Created on {date}\n" \
                       "\n" \
                       "{items}\n" \
-                      "TOTAL: <b>{value}</b>\n" \
-                      "\n" \
-                      "Customer notes: {notes}\n"
+                      "TOTAL: <b>{value}</b>\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>Order {status_text}</b>\n" \
                            "{items}\n" \
-                           "TOTAL: <b>{value}</b>\n" \
-                           "\n" \
-                           "Notes: {notes}\n"
+                           "TOTAL: <b>{value}</b>\n"
+
+order_notes_string = "Notes: {notes}\n"
+
+order_info_name = "Name: {name}\n"
+order_info_phone = "Phone: {phone}\n"
+order_info_email = "E-mail: {email}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>Loading transactions...\n" \

--- a/strings/es_mx.py
+++ b/strings/es_mx.py
@@ -29,16 +29,14 @@ order_format_string = "por {user}\n" \
                       "Creado en {date}\n" \
                       "\n" \
                       "{items}\n" \
-                      "TOTAL: <b>{value}</b>\n" \
-                      "\n" \
-                      "Notas del Cliente: {notes}\n"
+                      "TOTAL: <b>{value}</b>\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>Orden {status_text}</b>\n" \
                            "{items}\n" \
-                           "TOTAL: <b>{value}</b>\n" \
-                           "\n" \
-                           "Notas: {notes}\n"
+                           "TOTAL: <b>{value}</b>\n"
+
+order_notes_string = "Notas: {notes}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>Cargando transacciones...\n" \

--- a/strings/he.py
+++ b/strings/he.py
@@ -27,16 +27,14 @@ order_format_string = "{user} על ידי\n" \
                       "{date} נוצר בתאריך\n" \
                       "\n" \
                       "{items}\n" \
-                      "<b>{value}</b>: סך הכל\n" \
-                      "\n" \
-                      "{notes}: הערות הקונה\n"
+                      "<b>{value}</b>: סך הכל\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>הזמנה {status_text}</b>\n" \
                            "{items}\n" \
-                           "סך הכל: <b>{value}</b>\n" \
-                           "\n" \
-                           "הערות: {notes}\n"
+                           "סך הכל: <b>{value}</b>\n"
+
+order_notes_string = "הערות: {notes}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>טוען הזמנות...\n" \

--- a/strings/it.py
+++ b/strings/it.py
@@ -28,16 +28,18 @@ order_format_string = "di {user}\n" \
                       "Creato {date}\n" \
                       "\n" \
                       "{items}\n" \
-                      "TOTALE: <b>{value}</b>\n" \
-                      "\n" \
-                      "Note del cliente: {notes}\n"
+                      "TOTALE: <b>{value}</b>\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>Ordine {status_text}</b>\n" \
                            "{items}\n" \
-                           "TOTALE: <b>{value}</b>\n" \
-                           "\n" \
-                           "Note: {notes}\n"
+                           "TOTALE: <b>{value}</b>\n"
+
+order_notes_string = "Note: {notes}\n"
+
+order_info_name = "Nome: {name}\n"
+order_info_phone = "Telefono: {phone}\n"
+order_info_email = "E-mail: {email}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>Caricamento delle transazioni in corso...\n" \

--- a/strings/ru.py
+++ b/strings/ru.py
@@ -29,16 +29,18 @@ order_format_string = "Покупатель {user}\n" \
                       "Создано {date}\n" \
                       "\n" \
                       "{items}\n" \
-                      "ИТОГО: <b>{value}</b>\n" \
-                      "\n" \
-                      "Сообщение: {notes}\n"
+                      "ИТОГО: <b>{value}</b>\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>Заказ {status_text}</b>\n" \
                            "{items}\n" \
-                           "Итого: <b>{value}</b>\n" \
-                           "\n" \
-                           "Сообщение: {notes}\n"
+                           "Итого: <b>{value}</b>\n"
+
+order_notes_string = "Сообщение: {notes}\n"
+
+order_info_name = "Имя: {name}\n"
+order_info_phone = "Телефон: {phone}\n"
+order_info_email = "E-mail: {email}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>Загружаю транзакции...\n" \

--- a/strings/uk.py
+++ b/strings/uk.py
@@ -29,16 +29,18 @@ order_format_string = "Користувач {user}\n" \
                       "Створено {date}\n" \
                       "\n" \
                       "{items}\n" \
-                      "ЗАГАЛОМ: <b>{value}</b>\n" \
-                      "\n" \
-                      "Нотатка: {notes}\n"
+                      "ЗАГАЛОМ: <b>{value}</b>\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>Замовлення {status_text}</b>\n" \
                            "{items}\n" \
-                           "Загалом: <b>{value}</b>\n" \
-                           "\n" \
-                           "Нотатка: {notes}\n"
+                           "Загалом: <b>{value}</b>\n"
+
+order_notes_string = "Нотатка: {notes}\n"
+
+order_info_name = "ім'я: {name}\n"
+order_info_phone = "Телефон: {phone}\n"
+order_info_email = "E-mail: {email}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>Завантажую транзакції...\n" \

--- a/strings/zh_cn.py
+++ b/strings/zh_cn.py
@@ -29,16 +29,14 @@ order_format_string = "来自 {user}\n" \
                       "创建于 {date}\n" \
                       "\n" \
                       "{items}\n" \
-                      "总计: <b>{value}</b>\n" \
-                      "\n" \
-                      "客户注释: {notes}\n"
+                      "总计: <b>{value}</b>\n"
 
 # Order info string, shown to the user
 user_order_format_string = "{status_emoji} <b>订单 {status_text}</b>\n" \
                            "{items}\n" \
-                           "总计: <b>{value}</b>\n" \
-                           "\n" \
-                           "注释: {notes}\n"
+                           "总计: <b>{value}</b>\n"
+
+order_notes_string = "注释: {notes}\n"
 
 # Transaction page is loading
 loading_transactions = "<i>正在载入交易中...\n" \


### PR DESCRIPTION
1.  Fix brief order view from user.
2.  Save order_info to worker.
3.  Save worker.order_info in __order_transaction to db instead of empty row.
4.  Show order_info in full order view for admin.
5.  Hide notes if empty.

Don't use if you are not sure what you are doing.